### PR TITLE
Set owner of localstatedir/smrt 

### DIFF
--- a/hacking/platforms/ubuntu/ubuntu.sh
+++ b/hacking/platforms/ubuntu/ubuntu.sh
@@ -112,6 +112,8 @@ if [ ! -f /home/cif/.profile ]; then
 	chown $MYUSER:$MYGROUP /home/cif/.profile
 fi
 
+chown -R $MYUSER:$MYGROUP /var/smrt
+
 if [ -z `grep -l '/opt/cif/bin' /home/cif/.profile` ]; then
     MYPROFILE=/home/$MYUSER/.profile
     echo "" >> $MYPROFILE


### PR DESCRIPTION
I noted that that the cif user couldn't write to the /var/smrt/cache and hence the easybutton didn't deploy a working system, this should fix it, I hope. I'm on the irc channel as 'lochii'. 
