### PR TITLE
Fix the rule loading and yml configs

### DIFF
--- a/src/lib/CIF.pm
+++ b/src/lib/CIF.pm
@@ -87,8 +87,8 @@ sub parse_config {
 	my $config = shift;
     
 	return unless(-e $config);
-    $config = YAML::Tiny->read($config)->[0];
-    return $config;
+    my $config_data = YAML::Tiny->read($config) or croak("Cannot read $config, error: ", YAML::Tiny->errstr);
+    return $config_data->[0];
 }
 
 sub parse_rule {

--- a/src/rules/default/1d4_us.yml
+++ b/src/rules/default/1d4_us.yml
@@ -14,3 +14,4 @@ feeds:
     remote: http://1d4.us/archive/ssh-today.txt
     application: ssh
     portlist: 22
+

--- a/src/rules/default/alexa.yml
+++ b/src/rules/default/alexa.yml
@@ -36,3 +36,4 @@ feeds:
     start: 1
     end: 10
     confidence: 95
+

--- a/src/rules/default/aper.yml
+++ b/src/rules/default/aper.yml
@@ -17,3 +17,4 @@ feeds:
     confidence: 85
     description: 'address used in replyto/from header'
     pattern: '^(\S+),[A|B],(\S+)$'
+

--- a/src/rules/default/arbor.yml
+++ b/src/rules/default/arbor.yml
@@ -14,3 +14,4 @@ feeds:
     remote: http://atlas-public.ec2.arbor.net/public/ssh_attackers
     application: ssh
     portlist: 22
+

--- a/src/rules/default/bambenekconsulting_com.yml
+++ b/src/rules/default/bambenekconsulting_com.yml
@@ -23,3 +23,4 @@ feeds:
     tags:
       - botnet
       - gozi
+

--- a/src/rules/default/botscout.yml
+++ b/src/rules/default/botscout.yml
@@ -18,3 +18,4 @@ feeds:
       - null
       - observable
       - null
+

--- a/src/rules/default/bruteforceblocker.yml
+++ b/src/rules/default/bruteforceblocker.yml
@@ -14,3 +14,4 @@ feeds:
     values:
       - observable
       - lasttime
+

--- a/src/rules/default/crimetracker_net.yml
+++ b/src/rules/default/crimetracker_net.yml
@@ -10,3 +10,4 @@
     # pattern: ^(\S+)$
     # values: observable
     # remote: http://cybercrime-tracker.net/all.php
+

--- a/src/rules/default/drg.yml
+++ b/src/rules/default/drg.yml
@@ -21,3 +21,4 @@ feeds:
     remote: http://dragonresearchgroup.org/insight/vncprobe.txt
     application: vnc
     portlist: 5900-5904
+

--- a/src/rules/default/dshield.yml
+++ b/src/rules/default/dshield.yml
@@ -10,3 +10,4 @@ feeds:
     pattern: ^(\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)
     values:
       - observable
+

--- a/src/rules/default/feodotracker.yml
+++ b/src/rules/default/feodotracker.yml
@@ -21,3 +21,4 @@ feeds:
     values:
       - observable
     confidence: 65
+

--- a/src/rules/default/isc_sans_edu.yml
+++ b/src/rules/default/isc_sans_edu.yml
@@ -16,3 +16,4 @@ feeds:
   domains_high:
     confidence: 85
     remote: http://isc.sans.edu/feeds/suspiciousdomains_High.txt
+

--- a/src/rules/default/malc0de.yml
+++ b/src/rules/default/malc0de.yml
@@ -24,3 +24,4 @@ feeds:
       # link:
         # pattern: '(\S+)'
         # values: altid
+

--- a/src/rules/default/malwaredomains.yml
+++ b/src/rules/default/malwaredomains.yml
@@ -35,3 +35,4 @@ feeds:
     confidence: 85
     pattern: '^(\S+)'
     values: observable
+

--- a/src/rules/default/mirc.yml
+++ b/src/rules/default/mirc.yml
@@ -15,3 +15,4 @@ feeds:
     values:
       - observable
       - portlist
+

--- a/src/rules/default/nothink_org.yml
+++ b/src/rules/default/nothink_org.yml
@@ -13,3 +13,4 @@ feeds:
     remote: http://www.nothink.org/blacklist/blacklist_ssh_day.txt
     application: ssh
     portlist: 22
+

--- a/src/rules/default/openphish.yml
+++ b/src/rules/default/openphish.yml
@@ -10,3 +10,4 @@ feeds:
   urls:
     pattern: ^(\S+)$
     remote: http://openphish.com/feed.txt
+

--- a/src/rules/default/phishtank.yml
+++ b/src/rules/default/phishtank.yml
@@ -26,3 +26,4 @@ feeds:
       - description
       - altid
       - additional_data
+

--- a/src/rules/default/spamhaus.yml
+++ b/src/rules/default/spamhaus.yml
@@ -17,3 +17,4 @@ feeds:
     remote: http://www.spamhaus.org/drop/drop.lasso
   edrop:
     remote: http://www.spamhaus.org/drop/edrop.txt
+

--- a/src/rules/default/sshbl.yml
+++ b/src/rules/default/sshbl.yml
@@ -13,3 +13,4 @@ feeds:
     altid_tlp: green
     values:
       - observable
+

--- a/src/rules/default/zeustracker.yml
+++ b/src/rules/default/zeustracker.yml
@@ -46,3 +46,4 @@ feeds:
     values:
       - observable
     confidence: 65
+

--- a/src/rules/disabled/alienvault.yml
+++ b/src/rules/disabled/alienvault.yml
@@ -29,3 +29,4 @@ feeds:
   malware:
     pattern: '^(\b(?:\d{1,3}\.){3}\d{1,3}\b).*#.*(Malware IP|Malware Domain|Malicious Host|Malware distribution|RBN);?.*'
     tags: malware
+

--- a/src/rules/disabled/malekal.yml
+++ b/src/rules/disabled/malekal.yml
@@ -19,3 +19,4 @@ feeds:
       - address
     values:
       - observable
+

--- a/src/rules/disabled/spyeyetracker.yml
+++ b/src/rules/disabled/spyeyetracker.yml
@@ -46,3 +46,4 @@ feeds:
     values:
       - observable
     confidence: 65
+

--- a/src/rules/example/freeform.yml
+++ b/src/rules/example/freeform.yml
@@ -16,3 +16,4 @@ feeds:
     ignore: '^Backdoor.APT.|\.[dll|exe|hlp|rar]'
     altid: http://www.fireeye.com/blog/technical/targeted-attack/2014/06/clandestine-fox-part-deux.htm
     altid_tlp: green
+

--- a/src/rules/example/haleys_org.yml
+++ b/src/rules/example/haleys_org.yml
@@ -14,3 +14,4 @@ feeds:
     remote: http://charles.the-haleys.org/ssh_dico_attack_hdeny_format.php/hostsdeny.txt
     application: ssh
     portlist: 22
+

--- a/src/rules/example/malware_patrol.yml
+++ b/src/rules/example/malware_patrol.yml
@@ -37,3 +37,4 @@ feeds:
        - description
      altid: http://www.malware.com.br/cgi/search.pl?id=<id>
      altid_tlp: amber
+

--- a/src/rules/example/passivedns.yml
+++ b/src/rules/example/passivedns.yml
@@ -14,3 +14,4 @@ feeds:
       - rdata
       - observable
     lasttime: <firsttime>
+

--- a/src/rules/example/pastebin.yml
+++ b/src/rules/example/pastebin.yml
@@ -12,3 +12,4 @@ feed:
     confidence: 75
     pattern: '^([a-zA-Z-\.]+\.[a-z]{2,3})'
     values: observable
+

--- a/src/rules/example/shadowserver.yml
+++ b/src/rules/example/shadowserver.yml
@@ -25,3 +25,4 @@ feeds:
       - rdata
       - asn
       - cc
+


### PR DESCRIPTION
Since the configs were moved to YAML, some of them were missing a newline at eof or had DOS EOL.

Fixed the rule loading to die with a meaningful error instead of an obscure one.

Before:
Can't use an undefined value as an ARRAY reference at site/lib/CIF.pm line 90.

After:
Cannot read /opt/cif/etc/rules/default//1d4_us.yml, error: Stream does
not end with newline character at bin/cif-smrt line 283.

Also fixed all the involved yml configs so that cif-smrt starts up
properly.