### PR TITLE
cif-smrt: add --https_proxy option, work around LWP bug, see #195

### DIFF
--- a/src/bin/cif-smrt
+++ b/src/bin/cif-smrt
@@ -35,6 +35,7 @@ my $timeout     = 900;
 my $no_verify_ssl = 1; ##TODO alphas only!!!
 my $ignore_journal;
 my $proxy;
+my $https_proxy;
 
 # daemon
 my $daemon      = 0;
@@ -98,6 +99,7 @@ GetOptions(
     'not-before=s'       => \$notbefore,
     'cache|P=s'         => \$cache,
     'proxy=s'           => \$proxy,
+    'https-proxy=s'     => \$https_proxy,
     
     #notification
     'notify'        => \$notify,
@@ -135,6 +137,7 @@ if(-e $config){
     $no_verify_ssl  = $config->{'no_verify_ssl'} if($config->{'no_verify_ssl'} && !$no_verify_ssl);
     
     $proxy          = $proxy    || $config->{'proxy'};
+    $https_proxy    = $https_proxy || $config->{'https_proxy'};
 }
 
 sub usage {
@@ -157,6 +160,7 @@ Usage: $0 [OPTIONS] [-D status|start|stop|restart|reload]
     --limit=INT             limit parsing to a subset of records (useful for debugging)
     
     --proxy                 specify a proxy address for cif-smrt to use in fetching feeds
+    --https-proxy           specify a proxy for cif-smrt to use for feeds hosted on https
     
  Daemon Options:
     -D, --daemon            run as daemon
@@ -325,6 +329,7 @@ sub _main {
                 not_before      => $notbefore,
                 limit           => $limit,
                 proxy           => $proxy,
+                https_proxy     => $https_proxy,
             });
             
             try {

--- a/src/lib/CIF/Smrt.pm
+++ b/src/lib/CIF/Smrt.pm
@@ -26,7 +26,7 @@ use constant {
     MAX_DT          => '2100-12-31T23:59:59Z' # if you're still using this by then, God help you.
 };
 
-has [qw(ignore_journal config is_test other_attributes test_mode handler rule tmp limit proxy)] => (
+has [qw(ignore_journal config is_test other_attributes test_mode handler rule tmp limit proxy https_proxy)] => (
     is      => 'ro',
 );
 
@@ -53,9 +53,10 @@ sub _build_fetcher {
     my $self = shift;
 
     return CIF::Smrt::Fetcher->new({
-        rule    => $self->rule,
-        tmp     => $self->tmp_handle,
-        proxy   => $self->proxy,
+        rule        => $self->rule,
+        tmp         => $self->tmp_handle,
+        proxy       => $self->proxy,
+        https_proxy => $self->https_proxy,
     });
 }
 

--- a/src/lib/CIF/Smrt/Fetcher.pm
+++ b/src/lib/CIF/Smrt/Fetcher.pm
@@ -31,7 +31,7 @@ has 'agent'     => (
     default => AGENT,
 );
 
-has [qw(rule test_mode tmp username password proxy)] => (
+has [qw(rule test_mode tmp username password proxy https_proxy)] => (
     is      => 'ro'
 );
 
@@ -58,10 +58,12 @@ sub _build_handle {
         $agent->ssl_opts(verify_hostname => 0);
     }
 
+    $agent->env_proxy();
     if($self->proxy){
         $agent->proxy(['http','https'],$self->{'proxy'});
-    } else {
-        $agent->env_proxy();
+    }
+    if($self->https_proxy){
+        $agent->proxy(['https'],$self->{'https_proxy'});
     }
 
     return $agent;


### PR DESCRIPTION
LWP doesn't properly process the proxy environment variables.

`https_proxy` seems to be ignored or not used properly.
However, if you specify the proxy when initializing the `LWP::UserAgent`
as a `'connect://'` proxy, it works properly.
So: `cif-smrt .... --https_proxy=connect://proxy.addr.es:port/` will make
`cif-smrt` work properly if using a proxy is required by your network env
/ firewall configuration