### PR TITLE
CIF::Smrt::Fetcher: ensure proper ssl_opts for LWP. Related to #195

### DIFF
--- a/src/lib/CIF/Smrt/Fetcher.pm
+++ b/src/lib/CIF/Smrt/Fetcher.pm
@@ -56,6 +56,8 @@ sub _build_handle {
     if(defined($args->{'tls_verify'}) && !$args->{'tls_verify'}){
         $agent->ssl_opts(SSL_verify_mode => 'SSL_VERIFY_NONE');
         $agent->ssl_opts(verify_hostname => 0);
+    } else {
+        $agent->ssl_opts(SSL_verify_mode => 'SSL_VERIFY_PEER');
     }
 
     $agent->env_proxy();


### PR DESCRIPTION
For some reason LWP was not using the SSL_VERIFY_PEER option,
although according to IO::Socket::SSL docs that should be the default.

Related to issue #195 as well.