### PR TITLE
added debug parsing output to cif-smrt

### DIFF
--- a/src/lib/CIF/Smrt.pm
+++ b/src/lib/CIF/Smrt.pm
@@ -148,6 +148,8 @@ sub process {
         
         next unless($self->not_before <= $ts );
         $_ = $self->rule->process({ data => $_ });
+        local $Data::Dumper::Indent = 0;
+        $Logger->debug(Dumper($_));
 
         push(@array,$_);
     }


### PR DESCRIPTION
Added debug output for parsed values in cif-smrt. Output looks like:

```
[2015-05-12T12:53:19,146Z][DEBUG][CIF::Smrt:153]: $VAR1 = {'asn_desc' => 'ASINFIUM Infium LLC,RU','application' => 'ssh','confidence' => '85','firsttime' => '2015-05-12T06:30:23Z','provider' => 'dragonresearchgroup.org','asn' => '197145','protocol' => 'tcp','observable' => '188.190.115.58','group' => 'everyone','tlp' => 'amber','otype' => 'ipv4','tags' => 'scanner','lasttime' => '2015-05-12T06:30:23Z','portlist' => '22','altid_tlp' => 'green','altid' => 'http://dragonresearchgroup.org/insight/sshpwauth.txt','reporttime' => '2015-05-12T12:53:18Z'};
```

I am assuming I am using ```local $Data::Dumper::Indent = 0;``` correctly. 