### PR TITLE
change the ES limit values

### DIFF
--- a/src/lib/CIF/Storage/ElasticSearch.pm
+++ b/src/lib/CIF/Storage/ElasticSearch.pm
@@ -354,7 +354,7 @@ sub _search {
     
     my %search = (
         index   => $index,
-        size    => $filters->{'limit'} || 225000,
+        size    => $filters->{'limit'} || LIMIT,
         body    => $q,
     );
     
@@ -363,7 +363,7 @@ sub _search {
     if(is_ip($args->{'Query'})){
         %search = (
             index   => $index,
-            size    => 225000,
+            size    => LIMIT,
             body    => $q,
         );
     }

--- a/src/lib/CIF/Storage/ElasticSearch.pm
+++ b/src/lib/CIF/Storage/ElasticSearch.pm
@@ -25,8 +25,7 @@ use constant {
     MAX_COUNT           => 0,
     OBSERVABLES         => 'cif.observables',
     OBSERVABLES_TYPE    => 'observables',
-    LIMIT               => 50000,
-    
+    LIMIT               => 225000, #225,000 tuned for a ES box with 16GB of ram 
     TOKENS_INDEX        => 'cif.tokens',
     TOKENS_TYPE         => 'tokens',
 };
@@ -355,7 +354,7 @@ sub _search {
     
     my %search = (
         index   => $index,
-        size    => $filters->{'limit'} || 500000,
+        size    => $filters->{'limit'} || 225000,
         body    => $q,
     );
     
@@ -364,7 +363,7 @@ sub _search {
     if(is_ip($args->{'Query'})){
         %search = (
             index   => $index,
-            size    => 500000,
+            size    => 225000,
             body    => $q,
         );
     }

--- a/src/lib/CIF/Storage/ElasticSearch.pm
+++ b/src/lib/CIF/Storage/ElasticSearch.pm
@@ -25,7 +25,7 @@ use constant {
     MAX_COUNT           => 0,
     OBSERVABLES         => 'cif.observables',
     OBSERVABLES_TYPE    => 'observables',
-    LIMIT               => 225000, #225,000 tuned for a ES box with 16GB of ram 
+    LIMIT               => 225000, #225,000 tuned for a ElasticSearch build with 16GB of ram 
     TOKENS_INDEX        => 'cif.tokens',
     TOKENS_TYPE         => 'tokens',
 };


### PR DESCRIPTION
Tested a limit of 225k on a machine with 16GB of ram, a large search (```cif --feed --otype ipv4```) gets to about 13GB of ram usage and no swap.