### PR TITLE
update 00_whitelist.yml

### DIFF
--- a/src/rules/default/00_whitelist.yml
+++ b/src/rules/default/00_whitelist.yml
@@ -1,13 +1,33 @@
-defaults:
-  tlp: amber
-  provider: localhost
-  tags: whitelist
-  confidence: 85
+# To enable custom whitelist dataset(s)
+#
+# 1. Create the files below or choose a new remote location
+# 2. Populate the custom whitelist file
+# 3. Uncomment the the feeds section and associated
+#    parameters
 
-# example
-# feeds:
-#   domains:
-#     remote: /var/smrt/cache/localhost_whitelist_domains
-#     pattern: '^(\S+)$'
-#     values:
-#       - observable
+parser: regex
+defaults:
+  provider: localhost
+  tlp: amber
+  confidence: 95
+  tags: whitelist
+
+#feeds:
+#  domain_whitelist:
+#    remote: /var/smrt/localhost_whitelist_domains
+#    pattern: '^(\S+)$'
+#    values:
+#      - observable
+#    description: 'whitelisted domain'
+#  cidr_whitelist:
+#    remote: /var/smrt/localhost_whitelist_cidr
+#    pattern: '^(\S+)$'
+#    values:
+#      - observable
+#    description: 'whitelisted cidr'
+#  url_whitelist:
+#    remote: /var/smrt/localhost_whitelist_url
+#    pattern: '^(\S+)$'
+#    values:
+#      - observable
+#    description: 'whitelisted url'


### PR DESCRIPTION
updated 00_whitelist.yml:

1. changed the example file location from /var/smrt/cache as I think those files would get wiped out with cif-smrt --clean (i did not test but local whitelist data doesn't seem like 'cache' data to me)

2. Added cir and url examples

3. added some instructions