### PR TITLE
Fix README.md typo with host versus container port

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -7,5 +7,4 @@ A means of prototyping and testing the CIF v2 environment before rolling into pr
     aeppert/cifv2
 
 # Example Command Line
-    docker run -d -p 443:8443 -p 5000:5000 -p 9200:9200 aeppert/cifv2
-
+    docker run -d -p 8443:443 -p 5000:5000 -p 9200:9200 aeppert/cifv2


### PR DESCRIPTION
Sorry. I was just re-reading this and realized I swapped the ports.