### PR TITLE
additional updates to ansible cluster config

### DIFF
--- a/ansible/roles/debops.elasticsearch/defaults/main.yml
+++ b/ansible/roles/debops.elasticsearch/defaults/main.yml
@@ -29,13 +29,13 @@ elasticsearch_version: '1.4'
 
 # ---- Cluster ----
 
-elasticsearch_cluster_name: 'elasticsearch'
+elasticsearch_cluster_name: 'cifv2_elasticsearch'
 
 
 # ---- Node ----
 
 # An empty name will let elasticsearch randomly generate one for you.
-elasticsearch_node_name: ''
+elasticsearch_node_name: '{{ ansible_hostname }}'
 
 elasticsearch_node_master: true
 elasticsearch_node_data: true

--- a/ansible/roles/debops.elasticsearch/files/determine_es_heap_size.py
+++ b/ansible/roles/debops.elasticsearch/files/determine_es_heap_size.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+
+'''
+This script is used to determine the ES_HEAP_SIZE on a 
+ElasticSearch server during installation. 
+
+It queries the total memory from /proc/meminfo, then does
+calculations to determine a sane ES_HEAP_SIZE value. 
+
+It is designed to be called by Ansible and have the value be set
+via a Jinja template. 
+'''
+
+import re
+
+# Pattern matching 'MemTotal:        1016984 kB'
+pattern = '^MemTotal:\s+([0-9]+)\skB'
+regex = re.compile(pattern)
+meminfo = ''
+
+# read in /proc/meminfo
+try:
+    with open('/proc/meminfo', 'r') as f:
+        meminfo = f.read()
+except IOError:
+    pass
+
+# find MemTotal value from /proc/meminfo
+results = regex.findall(meminfo)
+
+if results:
+    
+    # turn result into an int
+    mem_total_kilobytes = int(results[0])
+
+    # 1048576 kB = 1GB
+    if mem_total_kilobytes < 1048576:
+        # mem less than 1G of mem, set ES_HEAP_SIZE to 
+        # 256mb
+        print("256m")
+    # if total mem between 1gb and 2gb, use 25% for ES        
+    elif mem_total_kilobytes >= 1048576 and mem_total_kilobytes <= 2097152:
+        calculated_value = ( int(round((mem_total_kilobytes * .25) / 1024)))
+        print("{0}m".format(calculated_value))
+    # if total mem between 2gb and 59.5 gb, use 50% for ES
+    elif mem_total_kilobytes >= 2097153 and mem_total_kilobytes <= 62390272:
+        calculated_value = ( int(round((mem_total_kilobytes * .50) / 1024)))
+        print("{0}m".format(calculated_value))
+    # if total mem over 59.5 GB, set max value at 30.5 GB
+    # https://goo.gl/ilHkld
+    else:
+        print("30500m")
+
+else:
+    # /proc/meminfo can't be read, set ES_HEAP_SIZE to 256mb
+    print("256m")
+

--- a/ansible/roles/debops.elasticsearch/tasks/install.yml
+++ b/ansible/roles/debops.elasticsearch/tasks/install.yml
@@ -16,14 +16,33 @@
   command: dpkg-divert --quiet --local --divert {{ elasticsearch_path_conf }}/{{ item }}.yml.dpkg-divert --rename {{ elasticsearch_path_conf }}/{{ item }}.yml creates={{ elasticsearch_path_conf }}/{{ item }}.yml.dpkg-divert
   with_items: [ 'elasticsearch', 'logging' ]
 
+- name: Copy determine_es_heap_size.py to es host
+  copy: src=determine_es_heap_size.py dest=/tmp/determine_es_heap_size.py
+        owner=root group=root mode=0644
+
+- name: Execute determine_es_heap_size.py to get recommended es_heap_size
+  command: /usr/bin/python /tmp/determine_es_heap_size.py
+  register: recommended_es_heap_size
+
 - name: Configure Elasticsearch
   template: src={{ item[1:] }}.j2 dest={{ item }}
-            owner=root group=elasticsearch mode=0640
+            owner=root group=elasticsearch mode=0644
   with_items:
     - '/etc/default/elasticsearch'
     - '{{ elasticsearch_path_conf }}/elasticsearch.yml'
     - '{{ elasticsearch_path_conf }}/logging.yml'
   notify: [ 'Restart Elasticsearch' ]
+
+- name: Configure limits.conf
+  template: src=etc/security/limits.conf.j2 dest=/etc/security/limits.conf
+            mode=0644 owner=root group=root
+
+- name: Configure sysctl.conf
+  template: src=etc/sysctl.conf.j2 dest=/etc/sysctl.conf
+            mode=0644 owner=root group=root
+
+- name: "Run sysctl to enable sysctl vm.swappiness=1"
+  command: sysctl vm.swappiness=1
 
 - name: Start Elasticsearch
   service: name=elasticsearch state=started enabled=True

--- a/ansible/roles/debops.elasticsearch/templates/etc/security/limits.conf.j2
+++ b/ansible/roles/debops.elasticsearch/templates/etc/security/limits.conf.j2
@@ -1,0 +1,58 @@
+# /etc/security/limits.conf
+#
+#Each line describes a limit for a user in the form:
+#
+#<domain>        <type>  <item>  <value>
+elasticsearch - nofile 65535
+elasticsearch - memlock unlimited
+
+#Where:
+#<domain> can be:
+#        - a user name
+#        - a group name, with @group syntax
+#        - the wildcard *, for default entry
+#        - the wildcard %, can be also used with %group syntax,
+#                 for maxlogin limit
+#        - NOTE: group and wildcard limits are not applied to root.
+#          To apply a limit to the root user, <domain> must be
+#          the literal username root.
+#
+#<type> can have the two values:
+#        - "soft" for enforcing the soft limits
+#        - "hard" for enforcing hard limits
+#
+#<item> can be one of the following:
+#        - core - limits the core file size (KB)
+#        - data - max data size (KB)
+#        - fsize - maximum filesize (KB)
+#        - memlock - max locked-in-memory address space (KB)
+#        - nofile - max number of open files
+#        - rss - max resident set size (KB)
+#        - stack - max stack size (KB)
+#        - cpu - max CPU time (MIN)
+#        - nproc - max number of processes
+#        - as - address space limit (KB)
+#        - maxlogins - max number of logins for this user
+#        - maxsyslogins - max number of logins on the system
+#        - priority - the priority to run user process with
+#        - locks - max number of file locks the user can hold
+#        - sigpending - max number of pending signals
+#        - msgqueue - max memory used by POSIX message queues (bytes)
+#        - nice - max nice priority allowed to raise to values: [-20, 19]
+#        - rtprio - max realtime priority
+#        - chroot - change root to directory (Debian-specific)
+#
+#<domain>      <type>  <item>         <value>
+#
+
+#*               soft    core            0
+#root            hard    core            100000
+#*               hard    rss             10000
+#@student        hard    nproc           20
+#@faculty        soft    nproc           20
+#@faculty        hard    nproc           50
+#ftp             hard    nproc           0
+#ftp             -       chroot          /ftp
+#@student        -       maxlogins       4
+
+# End of file

--- a/ansible/roles/debops.elasticsearch/templates/etc/sysctl.conf.j2
+++ b/ansible/roles/debops.elasticsearch/templates/etc/sysctl.conf.j2
@@ -1,0 +1,63 @@
+#
+# /etc/sysctl.conf - Configuration file for setting system variables
+# See /etc/sysctl.d/ for additional system variables.
+# See sysctl.conf (5) for information.
+#
+
+#kernel.domainname = example.com
+
+vm.swappiness = 1
+
+# Uncomment the following to stop low-level messages on console
+#kernel.printk = 3 4 1 3
+
+##############################################################3
+# Functions previously found in netbase
+#
+
+# Uncomment the next two lines to enable Spoof protection (reverse-path filter)
+# Turn on Source Address Verification in all interfaces to
+# prevent some spoofing attacks
+#net.ipv4.conf.default.rp_filter=1
+#net.ipv4.conf.all.rp_filter=1
+
+# Uncomment the next line to enable TCP/IP SYN cookies
+# See http://lwn.net/Articles/277146/
+# Note: This may impact IPv6 TCP sessions too
+#net.ipv4.tcp_syncookies=1
+
+# Uncomment the next line to enable packet forwarding for IPv4
+#net.ipv4.ip_forward=1
+
+# Uncomment the next line to enable packet forwarding for IPv6
+#  Enabling this option disables Stateless Address Autoconfiguration
+#  based on Router Advertisements for this host
+#net.ipv6.conf.all.forwarding=1
+
+
+###################################################################
+# Additional settings - these settings can improve the network
+# security of the host and prevent against some network attacks
+# including spoofing attacks and man in the middle attacks through
+# redirection. Some network environments, however, require that these
+# settings are disabled so review and enable them as needed.
+#
+# Do not accept ICMP redirects (prevent MITM attacks)
+#net.ipv4.conf.all.accept_redirects = 0
+#net.ipv6.conf.all.accept_redirects = 0
+# _or_
+# Accept ICMP redirects only for gateways listed in our default
+# gateway list (enabled by default)
+# net.ipv4.conf.all.secure_redirects = 1
+#
+# Do not send ICMP redirects (we are not a router)
+#net.ipv4.conf.all.send_redirects = 0
+#
+# Do not accept IP source route packets (we are not a router)
+#net.ipv4.conf.all.accept_source_route = 0
+#net.ipv6.conf.all.accept_source_route = 0
+#
+# Log Martian Packets
+#net.ipv4.conf.all.log_martians = 1
+#
+

--- a/ansible/roles/debops.elasticsearch/vars/main.yml
+++ b/ansible/roles/debops.elasticsearch/vars/main.yml
@@ -20,8 +20,8 @@ elasticsearch_path_lib: '{{ elasticsearch_path_home }}/lib'
 
 # --- Memory ---
 
-elasticsearch_memory_heap_size: '{{ (ansible_memtotal_mb | int * elasticsearch_memory_heap_size_multiplier) | round | int }}m'
-
+#elasticsearch_memory_heap_size: '{{ (ansible_memtotal_mb | int * elasticsearch_memory_heap_size_multiplier) | round | int }}m'
+elasticsearch_memory_heap_size: '{{ recommended_es_heap_size.stdout_lines[0] }}'
 
 # --- Discovery ---
 


### PR DESCRIPTION
fixes #377 

1. Set elasticsearch_cluster_name: 'cifv2_elasticsearch'
2. Set elasticsearch_node_name: '{{ ansible_hostname }}'
3. Set sysctl.conf.j2 to enable vm.swappiness = 1
4. Run the command "sysctl vm.swappiness=1" to set vm.swappiness without the need to reboot
5. Update permissions of elasticsearch config files to 0644
6. added determine_es_heap_size.py to ansible deployment
7. added functionality to set es_heap_size with a script to better set the value.
8. add /etc/security/limits.conf file with ES parameters