### PR TITLE
Fixing static mmdb file location

### DIFF
--- a/src/lib/CIF/Meta/GeoIP.pm
+++ b/src/lib/CIF/Meta/GeoIP.pm
@@ -23,7 +23,7 @@ use Data::Dumper;
 
 sub _build_handle {
     my $self = shift;
-    my $x = GeoIP2::Database::Reader->new(file => '/var/cache/GeoLite2-City.mmdb');
+    my $x = GeoIP2::Database::Reader->new(file => FILE_LOC());
     return $x;
 }
 


### PR DESCRIPTION
Location of GeoLite2-City.mmdb file was statically assigned. Changed to FILE_LOC constant.