### PR TITLE
added sipquery.txt

### DIFF
--- a/src/rules/default/dataplane.yml
+++ b/src/rules/default/dataplane.yml
@@ -24,3 +24,10 @@ feeds:
     portlist: 22
     confidence: 75
     description: 'has been seen initiating an SSH connection'
+  sipquery:
+    remote: https://dataplane.org/sipquery.txt
+    application: sip
+    protocol: udp
+    portlist: 5060
+    confidence: 75 
+    description: 'seen initiating a SIP OPTIONS query to a remote host'


### PR DESCRIPTION
Technically OPTIONS queries can arrive over either UDP or TCP, but they practically I only ever see them over UDP.  I could create an additional field in the feed that will say what the L4 protocol field is if that would be better and more helpful.  Otherwise this might be fine for now?