### PR TITLE
FIX enable_metadata option ignored

### DIFF
--- a/ansible/roles/cifv2/templates/cif-starman.conf.j2
+++ b/ansible/roles/cifv2/templates/cif-starman.conf.j2
@@ -7,4 +7,6 @@
 #               "green" => "limited",
 #               "white" => "public"
 #       }
+#
+#       "enable_metadata" => '0' # disable metadata gathering
 }

--- a/hacking/platforms/ubuntu/cif-starman.conf
+++ b/hacking/platforms/ubuntu/cif-starman.conf
@@ -5,4 +5,6 @@
 #               "green" => "limited",
 #               "white" => "public"
 #       }
+#
+#	"enable_metadata" => '0' # disable metadata gathering
 }

--- a/src/lib/CIF/REST.pm
+++ b/src/lib/CIF/REST.pm
@@ -65,7 +65,7 @@ sub startup {
         CIF::Client->new({
             remote              => REMOTE,
             tlp_map             => $self->config('tlp_map'),
-            enable_meta_data    => (defined($self->config('enable_metadata'))) ? $self->config('enable_metadata') : 1
+            enable_metadata    => (defined($self->config('enable_metadata'))) ? $self->config('enable_metadata') : 1
         })
     });
     


### PR DESCRIPTION
Var name mismatch prevented this option to get used

Also added a commented line of the option in the conf file (both in hacking and ansible)